### PR TITLE
Load i18n stuff asynchronously

### DIFF
--- a/config/webpack/config.prod.js
+++ b/config/webpack/config.prod.js
@@ -13,6 +13,7 @@ const SWPrecacheWebpackPlugin = require("sw-precache-webpack-plugin");
 const merge = require("webpack-merge");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
   .BundleAnalyzerPlugin;
+const rxPaths = require("rxjs/_esm5/path-mapping");
 
 const commonConfig = require("./config.common");
 const paths = require("../paths");
@@ -79,6 +80,10 @@ module.exports = merge.smart(
         path
           .relative(paths.appSrc, info.absoluteResourcePath)
           .replace(/\\/g, "/")
+    },
+
+    resolve: {
+      alias: rxPaths()
     },
 
     plugins: [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
+    "redux-observable": "^0.17.0",
+    "rxjs": "^5.5.6",
     "webfontloader": "^1.6.28",
     "whatwg-fetch": "2.0.3"
   },

--- a/src/app/i18n/i18n.ts
+++ b/src/app/i18n/i18n.ts
@@ -1,20 +1,29 @@
 import { addLocaleData } from "react-intl";
-import languagePackDe from "./languagePacks/de";
-import languagePackEn from "./languagePacks/en";
-import { Translations } from "./languagePacks/languagePack";
+import { LanguagePack } from "./languagePacks/languagePack";
 
-addLocaleData([...languagePackDe.localeData, ...languagePackEn.localeData]);
-
-export function getMessagesForLang(lang: string): Translations {
-  switch (lang) {
-    case "de":
-      return languagePackDe.translations;
-    default:
-      return languagePackEn.translations;
-  }
+function registerLocaleData(module: { default: LanguagePack }): LanguagePack {
+  addLocaleData(module.default.localeData[0]);
+  return module.default;
 }
 
 export const BROWSER_LANGUAGE = navigator.language.slice(0, 2);
+
+export function loadLanguagePack(lang: string): Promise<LanguagePack> {
+  switch (lang) {
+    case "de":
+      return import(/* webpackChunkName: "lang-de" */ "./languagePacks/de").then(
+        registerLocaleData
+      );
+    default:
+      return import(/* webpackChunkName: "lang-en" */ "./languagePacks/en").then(
+        registerLocaleData
+      );
+  }
+}
+
+export function loadBrowserLanguagePack(): Promise<LanguagePack> {
+  return loadLanguagePack(BROWSER_LANGUAGE);
+}
 
 export function getSupportedLanguages(): string[] {
   return ["de", "en"]; // TODO: Optimize.

--- a/src/app/i18n/i18n.ts
+++ b/src/app/i18n/i18n.ts
@@ -1,4 +1,13 @@
 import { addLocaleData } from "react-intl";
+import { updateIntl } from "react-intl-redux";
+import { AnyAction } from "redux";
+import { ofType } from "redux-observable";
+
+import { Observable } from "rxjs/Observable";
+import { fromPromise } from "rxjs/observable/fromPromise";
+import { map } from "rxjs/operators/map";
+import { switchMap } from "rxjs/operators/switchMap";
+
 import { LanguagePack } from "./languagePacks/languagePack";
 
 function registerLocaleData(module: { default: LanguagePack }): LanguagePack {
@@ -28,3 +37,19 @@ export function loadBrowserLanguagePack(): Promise<LanguagePack> {
 export function getSupportedLanguages(): string[] {
   return ["de", "en"]; // TODO: Optimize.
 }
+
+export const LOAD_LANGUAGE = "loadLanguage";
+
+export const loadLanguageEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
+    ofType(LOAD_LANGUAGE),
+    switchMap((action: AnyAction) =>
+      fromPromise(loadLanguagePack(action.payload as string))
+    ),
+    map((langPack: LanguagePack) =>
+      updateIntl({
+        locale: langPack.language,
+        messages: langPack.translations
+      })
+    )
+  );

--- a/src/app/i18n/languagePacks/de.ts
+++ b/src/app/i18n/languagePacks/de.ts
@@ -4,5 +4,6 @@ import { LanguagePack } from "./languagePack";
 
 export default {
   translations: translationsDe,
-  localeData: de
+  localeData: de,
+  language: "de"
 } as LanguagePack;

--- a/src/app/i18n/languagePacks/en.ts
+++ b/src/app/i18n/languagePacks/en.ts
@@ -4,5 +4,6 @@ import { LanguagePack } from "./languagePack";
 
 export default {
   translations: translationsEn,
-  localeData: en
+  localeData: en,
+  language: "en"
 } as LanguagePack;

--- a/src/app/i18n/languagePacks/languagePack.ts
+++ b/src/app/i18n/languagePacks/languagePack.ts
@@ -3,6 +3,7 @@ export interface Translations {
 }
 
 export interface LanguagePack {
+  language: string;
   translations: Translations;
   localeData: ReactIntl.LocaleData;
 }

--- a/src/app/language-picker/LanguagePicker.tsx
+++ b/src/app/language-picker/LanguagePicker.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { InjectedIntlProps, injectIntl } from "react-intl";
-import { IntlAction, updateIntl } from "react-intl-redux";
+import { IntlAction } from "react-intl-redux";
 import ListItem from "react-md/lib/Lists/ListItem";
 import MenuButton from "react-md/lib/Menus/MenuButton";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
-import { getSupportedLanguages, loadLanguagePack } from "../i18n/i18n";
+import { getSupportedLanguages, LOAD_LANGUAGE } from "../i18n/i18n";
 import { AppState } from "../state";
 
 export interface LanguagePickerProps {
@@ -23,14 +23,7 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = (dispatch: Dispatch<IntlAction>) => {
   return {
     setLanguage: (lang: string) => {
-      loadLanguagePack(lang).then(({ translations }) => {
-        dispatch(
-          updateIntl({
-            locale: lang,
-            messages: translations
-          })
-        );
-      });
+      dispatch({ type: LOAD_LANGUAGE, payload: lang });
     }
   };
 };

--- a/src/app/language-picker/LanguagePicker.tsx
+++ b/src/app/language-picker/LanguagePicker.tsx
@@ -6,7 +6,7 @@ import MenuButton from "react-md/lib/Menus/MenuButton";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
-import { getMessagesForLang, getSupportedLanguages } from "../i18n/i18n";
+import { getSupportedLanguages, loadLanguagePack } from "../i18n/i18n";
 import { AppState } from "../state";
 
 export interface LanguagePickerProps {
@@ -23,12 +23,14 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = (dispatch: Dispatch<IntlAction>) => {
   return {
     setLanguage: (lang: string) => {
-      dispatch(
-        updateIntl({
-          locale: lang,
-          messages: getMessagesForLang(lang)
-        })
-      );
+      loadLanguagePack(lang).then(({ translations }) => {
+        dispatch(
+          updateIntl({
+            locale: lang,
+            messages: translations
+          })
+        );
+      });
     }
   };
 };

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -1,7 +1,8 @@
 import { intlReducer, IntlState } from "react-intl-redux";
 import { combineReducers, Reducer } from "redux";
 
-import { BROWSER_LANGUAGE, getMessagesForLang } from "./i18n/i18n";
+import { BROWSER_LANGUAGE } from "./i18n/i18n";
+import { Translations } from "./i18n/languagePacks/languagePack";
 import {
   initialTodoList,
   todosReducer,
@@ -13,13 +14,15 @@ export interface AppState {
   intl: IntlState;
 }
 
-export const initialAppState: AppState = {
-  todos: initialTodoList,
-  intl: {
-    locale: BROWSER_LANGUAGE,
-    messages: getMessagesForLang(BROWSER_LANGUAGE)
-  }
-};
+export function initialAppState(messages: Translations): AppState {
+  return {
+    todos: initialTodoList,
+    intl: {
+      locale: BROWSER_LANGUAGE,
+      messages
+    }
+  };
+}
 
 export default combineReducers<AppState>({
   todos: todosReducer as Reducer<any>,

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,13 +1,12 @@
 import { createStore, Reducer, Store } from "redux";
-import rootReducer, { AppState, initialAppState } from "./state";
+import rootReducer, { AppState } from "./state";
 
 export default function configureStore(
-  initialState: AppState | null
+  initialState: AppState
 ): Store<AppState> {
-  const initState = initialState || initialAppState;
   const store = createStore(
     rootReducer,
-    initState,
+    initialState,
     window["__REDUX_DEVTOOLS_EXTENSION__"] &&
       window["__REDUX_DEVTOOLS_EXTENSION__"]()
   );

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,14 +1,22 @@
-import { createStore, Reducer, Store } from "redux";
+import { applyMiddleware, compose, createStore, Reducer, Store } from "redux";
+import { combineEpics, createEpicMiddleware } from "redux-observable";
 import rootReducer, { AppState } from "./state";
+
+import { loadLanguageEpic } from "./i18n/i18n";
 
 export default function configureStore(
   initialState: AppState
 ): Store<AppState> {
+  const rootEpic = combineEpics(loadLanguageEpic);
+  const epicMiddleware = createEpicMiddleware(rootEpic);
+
+  const composeEnhancers =
+    window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] || compose;
+
   const store = createStore(
     rootReducer,
     initialState,
-    window["__REDUX_DEVTOOLS_EXTENSION__"] &&
-      window["__REDUX_DEVTOOLS_EXTENSION__"]()
+    composeEnhancers(applyMiddleware(epicMiddleware))
   );
 
   if (module.hot) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,6 +7145,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-observable@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.17.0.tgz#23e29e3f3c39204b7ed6a14b67a29e317c03106b"
+
 redux@^3.6.0, redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -7568,7 +7572,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@^5.4.2:
+rxjs@^5.4.2, rxjs@^5.5.6:
   version "5.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
   dependencies:


### PR DESCRIPTION
Splits the i18n related stuff to one chunk per language, thus reducing the initial payload.

While this is possible without `redux-observable`, that one will be useful for additional purposes later on - and I did not want to use a different way for loading i18n when there is already a reusable one...